### PR TITLE
Remove F# from not IDE-friendly list

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ In a nutshell, Keli strives to fill the hole in the table below, which is to be 
 |  | Functional Programming | Non-functional programming |
 | :--- | :--- | :--- |
 | IDE-friendly | ? | C\#, Smalltalk, Java |
-| Not IDE-friendly | Haskell, F\#, OCaml | Perl, C, Bash |
+| Not IDE-friendly | Haskell, OCaml | Perl, C, Bash |
 
 
 


### PR DESCRIPTION
The statement that F# isn't IDE-friendly is absolutely incorrect and discredits the work done by the F# community to make the state-of-the-art tooling that is currently available for F#. 

For a long time, F# users have enjoying great IDE solutions such as with [VS Code Ionide](https://github.com/ionide/ionide-vscode-fsharp), [Visual Studio](https://visualstudio.microsoft.com) and [JetBrains Rider](https://www.jetbrains.com/rider) 

These solution already offer everything one would come to expect from an IDE such as project-wide analysis, type-safe refactorings and context-aware hints. Not to forget the integrated debugger in all of these IDEs.

As for the core F# language, it is absolutely IDE friendly when the API design is carefully built with intellisense in mind. This is why we use the `|>` operator with fully qualified modules
```fs
[1 .. 10]
|> List.filter (fun n -> n < 2)
|> List.map (fun n -> n * 2)
```
And this is only the start, F# can use the same API facilities provided in C#/.NET such static functions with overloads. The [Feliz](https://zaid-ajaj.github.io/Feliz) library is built entirely based on this concept to make the best of the intellisense features. There are countless examples if you want more. 

Moreover, F# offers the [compiler services](https://fsharp.github.io/FSharp.Compiler.Service) as a standalone library which can be used from F# to build third-party static code analysis tools such as [this one](https://github.com/Zaid-Ajaj/Npgsql.FSharp.Analyzer) 

I am happy to see the developments in functional programming world and the fact that you are building something that works nicely with IDEs from the get-go but don't discredit others work to promote your own. 